### PR TITLE
Make vec_hash_t a 64 bit type.

### DIFF
--- a/include/graph_zeppelin_common.h
+++ b/include/graph_zeppelin_common.h
@@ -11,4 +11,4 @@ typedef uint64_t edge_id_t; // Max number edges
 
 // sketching
 typedef uint64_t vec_t; //Max sketch vector size is 2^64 - 1
-typedef uint32_t vec_hash_t;
+typedef uint64_t vec_hash_t;


### PR DESCRIPTION
We encounter checksum failures when doing intensive sketch testing. That's bad.